### PR TITLE
Add Clone trait to ListNode

### DIFF
--- a/leetcode_prelude/src/linkedlist.rs
+++ b/leetcode_prelude/src/linkedlist.rs
@@ -6,7 +6,7 @@
 /// Please don't rely on it
 use std::fmt;
 
-#[derive(PartialEq, Eq, Ord, PartialOrd)]
+#[derive(PartialEq, Eq, Clone, Ord, PartialOrd)]
 pub struct ListNode {
     pub val: i32,
     pub next: Option<Box<ListNode>>,


### PR DESCRIPTION
Leetcode seems to implement Clone for ListNode, so it would be useful to have implement the trait too.

e.g. 
The comment to: https://leetcode.com/problems/remove-nth-node-from-end-of-list/
shows this implementation as a comment.
```
// Definition for singly-linked list.
#[derive(PartialEq, Eq, Clone, Debug)]
pub struct ListNode {
    pub val: i32,
    pub next: Option<Box<ListNode>>
}

impl ListNode {
    #[inline]
    fn new(val: i32) -> Self {
        ListNode {
             next: None,
            val
        }
    }
}
```