### PR TITLE
Process new arguments in leetcode_test

### DIFF
--- a/leetcode_test/src/lib.rs
+++ b/leetcode_test/src/lib.rs
@@ -57,7 +57,7 @@ trait ToArgs {
 impl ToArgs for Value {
     fn to_args(&self) -> String {
         let array = self.as_array().unwrap();
-        if array.len() == 0 {
+        if array.is_empty() {
             "".to_owned()
         } else {
             array
@@ -88,8 +88,9 @@ fn json_to_code(input: TokenStream) -> String {
 
     let mut code = String::new();
     code.push_str(&format!(
-        "let mut obj = {}::new();\n",
-        funcs[0].as_str().unwrap()
+        "let mut obj = {}::new({});\n",
+        funcs[0].as_str().unwrap(),
+        args[0].to_args(),
     ));
 
     for i in 1..funcs.as_array().unwrap().len() {

--- a/leetcode_test/tests/test.rs
+++ b/leetcode_test/tests/test.rs
@@ -1,7 +1,7 @@
 #![feature(proc_macro_hygiene)]
 
 use leetcode_test::leetcode_test_debug;
-
+#[rustfmt::skip]
 #[test]
 fn test() {
     assert_eq!(
@@ -12,6 +12,24 @@ fn test() {
         ),
         concat!(
             r#"let mut obj = Trie::new();"#, "\n",
+            r#"obj.insert(1, "apple".to_owned());"#, "\n",
+            r##"assert_eq!(obj.search("apple".to_owned()), true, r#"obj.search("apple".to_owned())"#);"##, "\n",
+            r##"assert_eq!(obj.search("app".to_owned()), false, r#"obj.search("app".to_owned())"#);"##, "\n",
+        )
+    );
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_with_new_args() {
+    assert_eq!(
+        leetcode_test_debug!(
+            ["Trie","insert","search","search"]
+            [["apple", "tree"],[1, "apple"],["apple"],["app"]]
+            [null,null,true,false]
+        ),
+        concat!(
+            r#"let mut obj = Trie::new("apple".to_owned(), "tree".to_owned());"#, "\n",
             r#"obj.insert(1, "apple".to_owned());"#, "\n",
             r##"assert_eq!(obj.search("apple".to_owned()), true, r#"obj.search("apple".to_owned())"#);"##, "\n",
             r##"assert_eq!(obj.search("app".to_owned()), false, r#"obj.search("app".to_owned())"#);"##, "\n",


### PR DESCRIPTION
- A problem like https://leetcode.com/problems/iterator-for-combination/
  requires the constructor be passed arguments. Correctly use the
  arguments passed as parameters.

- Add new test for constructor with arguments.
- Add `#[rustfmt::skip]` for those tests to avoid the tests being
  reformatted by rustfmt.

- Fix a clippy warning with use of `.len() == 0`