### PR TITLE
Process n-dimensional vec arguments in `leetcode_test`

### DIFF
--- a/leetcode_test/src/lib.rs
+++ b/leetcode_test/src/lib.rs
@@ -65,6 +65,8 @@ impl ToArgs for Value {
                 .map(|value| {
                     if value.is_string() {
                         format!("{}.to_owned()", value)
+                    } else if value.is_array() {
+                        format!("vec![{}]", value.to_args()) 
                     } else {
                         value.to_string()
                     }

--- a/leetcode_test/tests/test.rs
+++ b/leetcode_test/tests/test.rs
@@ -36,3 +36,22 @@ fn test_with_new_args() {
         )
     );
 }
+
+#[rustfmt::skip]
+#[test]
+fn test_with_nested_args() {
+    assert_eq!(
+        leetcode_test_debug!(
+            ["Graph", "shortestPath", "shortestPath", "addEdge", "shortestPath"]
+            [[4, [[0, 2, 5], [0, 1, 2], [1, 2, 1], [3, 0, 3]]], [3, 2], [0, 3], [[1, 3, 4]], [0, 3]]
+            [null, 6, -1, null, 6]
+        ),
+        concat!(
+            r#"let mut obj = Graph::new(4, vec![vec![0, 2, 5], vec![0, 1, 2], vec![1, 2, 1], vec![3, 0, 3]]);"#, "\n",
+            r##"assert_eq!(obj.shortest_path(3, 2), 6, r#"obj.shortest_path(3, 2)"#);"##, "\n",
+            r##"assert_eq!(obj.shortest_path(0, 3), -1, r#"obj.shortest_path(0, 3)"#);"##, "\n",
+            r#"obj.add_edge(vec![1, 3, 4]);"#, "\n",
+            r##"assert_eq!(obj.shortest_path(0, 3), 6, r#"obj.shortest_path(0, 3)"#);"##, "\n",
+        )
+    );
+}

--- a/leetcode_test/tests/test.rs
+++ b/leetcode_test/tests/test.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use leetcode_test::leetcode_test_debug;
 #[rustfmt::skip]
 #[test]


### PR DESCRIPTION
this problem https://leetcode.com/problems/design-graph-with-shortest-path-calculator/ passes vec and nested vec as argument, so I create this PR to 
1. recursively handle the array value in `ToArgs` trait
2. add test case for it, which is the example of that leetcode problem
3. remove unneeded feature flag because it's now stable